### PR TITLE
Use local variable instead of prototype for original onSocket

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ function toCurl(platform) {
     return command.join(' ');
 }
 
-http.ClientRequest.prototype._onSocket = http.ClientRequest.prototype.onSocket;
+const originalOnSocket = http.ClientRequest.prototype.onSocket;
 
 http.ClientRequest.prototype.onSocket = function onSocket(socket) {
     var self = this,
@@ -166,7 +166,7 @@ http.ClientRequest.prototype.onSocket = function onSocket(socket) {
         self.body = parseRequestBody(self._requestBody);
     });
 
-    this._onSocket(socket);
+    originalOnSocket.call(this, socket);
 };
 
 http.ClientRequest.prototype.toCurl = toCurl;


### PR DESCRIPTION
When combining this with other tools that modify the prototype of ClientRequest, this can cause an endless recursion.
This change uses a local variable to save the original onSocket call, which prevents this endless recursion.